### PR TITLE
Change extensions to fix github workflow tests.

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -83,7 +83,7 @@ jobs:
           yarn swc editor -d ./build-editor/
           checkBuild "editor" "build-editor"
 
-          tee spack.config.js <<EOF
+          tee spack.config.cjs <<EOF
           module.exports = {
             entry: {
               web: __dirname + "/src/Three.js",


### PR DESCRIPTION
Error in CI failure mentions this as a fix:
```
Run spack
yarn run v1.22.19
$ /home/runner/work/cli/cli/integration-tests/three.js/node_modules/.bin/spack
/home/runner/work/cli/cli/node_modules/@swc/core/spack.js:55
                throw new Error(`Error occurred while loading config file at ${config}: ${e}`);
                      ^
Error: Error occurred while loading config file at /home/runner/work/cli/cli/integration-tests/three.js/spack.config.js: Error [ERR_REQUIRE_ESM]: require() of ES Module /home/runner/work/cli/cli/integration-tests/three.js/spack.config.js from /home/runner/work/cli/cli/node_modules/@swc/core/spack.js not supported.
spack.config.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename spack.config.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /home/runner/work/cli/cli/integration-tests/three.js/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```